### PR TITLE
Remove container name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,17 @@
 version: '2'
 
-### Change the `project` with your own project name ###
 services:
     application:
-        container_name: project_application
         image: debian
         volumes:
             - ./:/var/www/laravel
     workspace:
-        container_name: project_workspace
         restart: always
         image: framgia/laravel-workspace
         volumes_from:
             - application
         tty: true
     php-fpm:
-        container_name: project_php-fpm
         restart: always
         image: framgia/laravel-php-fpm
         volumes_from:
@@ -25,7 +21,6 @@ services:
         links:
             - workspace
     nginx:
-        container_name: project_nginx
         restart: always
         image: framgia/laravel-nginx
         volumes_from:
@@ -37,25 +32,21 @@ services:
         links:
             - php-fpm
     data:
-        container_name: project_data
         image: debian
         volumes:
             - .docker/mysql:/var/lib/mysql
             - .docker/data:/data
     data_test:
-        container_name: project_data_test
         image: debian
         volumes:
             - .docker/mysql_test:/var/lib/mysql
             - .docker/data_test:/data
     logs:
-        container_name: project_logs
         image: debian
         volumes:
             - .docker/logs/nginx:/var/log/nginx
             - .docker/logs/mongodb:/var/log/mongodb
     mysql:
-        container_name: project_mysql
         restart: always
         image: mysql
         volumes_from:
@@ -69,7 +60,6 @@ services:
             MYSQL_PASSWORD: secret
             MYSQL_ROOT_PASSWORD: root
     mysql_test:
-        container_name: project_mysql_test
         restart: always
         image: mysql
         volumes_from:
@@ -82,7 +72,6 @@ services:
             MYSQL_PASSWORD: secret
             MYSQL_ROOT_PASSWORD: root
     mongo:
-        container_name: project_mongo
         restart: always
         image: mongo
         expose:
@@ -91,7 +80,6 @@ services:
             - data
             - logs
     redis:
-        container_name: project_redis
         restart: always
         image: redis
         expose:

--- a/readme.md
+++ b/readme.md
@@ -19,12 +19,12 @@ The following containers will be run by default:
 
 ## Usage
 - Copy file `docker-compose.yml` to your Laravel folder.
-- You should change the `project` keyword with your real project name in `docker-compose.yml` file.
 - You have to change the database's variables to fit your `.env` file configuration
 - If you do not need any services (such as `mongodb` or `redis`), simply remove it from `docker-compose.yml`
 - The project's persistant data (mysql, redis, mongodb data ...) will be stored inside this `.docker` folder. It should be added to `.gitignore`.
 - Run `docker-compose up -d` and enjoy.
-- Run `docker exec -it project_workspace bash` to enter workspace container. You can run `php artisan` command inside this container.
+- Run `docker-compose ps` to check containers status.
+- Run `docker-compose exec workspace bash` to enter `workspace` container. You can run `php artisan` command inside this container.
 
 ## Links
 Our `docker-compose.yml` is powered by the following images:


### PR DESCRIPTION
Em thấy khai báo container name không có nhiều lợi ích, mà lại mất công thêm bước đổi tên project?

Em nghĩ để cho docker-compose tự động sinh tên container, còn run command thông qua service name:
```
sudo docker-compose ps
sudo docker-compose exec workspace
```